### PR TITLE
Update sensor.py

### DIFF
--- a/custom_components/trakt/sensor.py
+++ b/custom_components/trakt/sensor.py
@@ -51,7 +51,7 @@ class TraktUpcomingCalendarSensor(Entity):
         return "shows"
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the state attributes of the sensor."""
         attributes = {
             "data": self.coordinator.data,


### PR DESCRIPTION
#https://github.com/custom-components/sensor.trakt/issues/62

This should fix the warning about device_state_attributes.

2021-12-19 08:53:17 WARNING (MainThread) [homeassistant.helpers.entity] Entity sensor.trakt_upcoming_calendar (<class 'custom_components.trakt.sensor.TraktUpcomingCalendarSensor'>) implements device_state_attributes. Please report it to the custom component author.
